### PR TITLE
fix(app): Upgrade checkTargets to yargs@3.5.4 syntax

### DIFF
--- a/lib/targets.js
+++ b/lib/targets.js
@@ -75,7 +75,7 @@ var checkTargets = exports.checkTargets = function(args, opts) {
 
     var message;
     if(!args.target) {
-        return;
+        return true;
     }
     var badTargets = _.difference([].concat(args.target), getAllTargets());
     if(badTargets.length !== 0) {
@@ -84,8 +84,9 @@ var checkTargets = exports.checkTargets = function(args, opts) {
 
         throw new Error(message);
     }
+
     if(!args.mode) {
-        return;
+        return true;
     }
 
     if(!_.isString(args.mode)) {
@@ -101,16 +102,19 @@ var checkTargets = exports.checkTargets = function(args, opts) {
 
         throw new Error(message);
     }
+
+    return true;
 };
 
 var checkSingleTarget = exports.checkSingleTarget = function(args, opts) {
     var message;
-    checkTargets(args, opts);
+    var retval = checkTargets(args, opts);
     if(_.isArray(args.target) && args.target.length > 1) {
         message = 'Only a single target can be used with this task, instead got: ' + args.target.toString();
         gutil.log(chalk.red('(ERR) ' + message));
         throw new Error(message);
     }
+    return retval;
 };
 
 var askForTargets = function(taskname, defaultTargets, defaultMode, checkFn) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash-deep": "1.4.2",
     "randomstring": "1.0.3",
     "run-sequence": "1.0.2",
-    "yargs": "1.3.3"
+    "yargs": "3.5.4"
   },
   "devDependencies": {
     "chai": "1.10.0",


### PR DESCRIPTION
Resolves #35, upgrades `yargs@1.3.3` dependency (added in #36) to `yargs@3.5.4`.